### PR TITLE
Add extra div cutoffs and substantial refactor

### DIFF
--- a/info.toml
+++ b/info.toml
@@ -9,3 +9,4 @@ siteid = 162
 [script]
 dependencies = [ "NadeoServices" ]
 imports = [ "Permissions.as", "Time.as" ]
+# defines = [ "DEV" ]

--- a/src/COTDStats.as
+++ b/src/COTDStats.as
@@ -19,6 +19,8 @@ const int MAX_DIV_TIME = 9999999;
 // Since COTD is at most ~120s, we can safely assume values for .time that are greater than (MAX_DIV_TIME >> 3) are dummy times.
 // So we use `MAX_DIV_TIME >> 3` as a comparison value.
 
+int lastUpdated = 0;
+
 class DivTime {
     string div;
     int time;
@@ -95,6 +97,9 @@ void Render() {
         UI::TableNextRow();
         UI::TableNextColumn();
         UI::Text(cotdName);
+        UI::TableNextRow();
+        UI::TableNextColumn();
+        UI::Text("Updated: " + ((Time::get_Now() - lastUpdated) / 1000.) + " s ago");
         UI::TableNextRow();
         UI::TableNextColumn();
         UI::Text("\\$aaa" + totalPlayers + " players (" + Math::Ceil(totalPlayers/64.0) + " divs)\\$z");
@@ -266,7 +271,7 @@ void UpdateFromAPI() {
         checkThisLoop = canCallAPI && mapid != "" && loopCounter == 0;
 
         if (checkThisLoop) {
-
+            lastUpdated = Time::get_Now();
             // trace("mapid:" + mapid);
 
             while (!NadeoServices::IsAuthenticated("NadeoClubServices")) {
@@ -384,7 +389,7 @@ class GameInfo {
     }
 
     CTrackManiaNetworkServerInfo@ GetServerInfo() {
-        return cast<CTrackManiaNetworkServerInfo>(network.ServerInfo);
+        return cast<CTrackManiaNetworkServerInfo>(GetNetwork().ServerInfo);
     }
 
     bool IsCotd() {

--- a/src/COTDStats.as
+++ b/src/COTDStats.as
@@ -219,7 +219,7 @@ void SetDivCutoff(CotdApi@ api, DivTime@&in divObj, int cid, string mid, int div
         // and don't request div cutoff times if the div isn't full
         if (div * 64 <= totalPlayers) {
             auto res = api.GetCutoffForDiv(cid, mid, div);
-            divObj.time = (res.Length > 0) ? res[0]["time"] : 0;
+            divObj.time = (res.Length > 0) ? res[0]["time"] : MAX_DIV_TIME;
         } else { // when the division isn't full
             divObj.time = MAX_DIV_TIME;
         }
@@ -309,6 +309,9 @@ void UpdateFromAPI() {
                 belowdiv.hidden = true;
             }
 
+            if (curdiv + 1 > Math::Ceil(totalPlayers / 64.)) {
+                belowdiv.hidden = true;
+            }
         } else {
             if (!canCallAPI) {
                 // Reset challenge id once COTD ends
@@ -371,17 +374,22 @@ class CotdApi {
 
 class GameInfo {
     CTrackMania@ app; // = GetTmApp();
-    // todo: these references might change -- refactor to getter functions or something
-    CTrackManiaNetwork@ network; // = cast<CTrackManiaNetwork>(app.Network);
-    CTrackManiaNetworkServerInfo@ server_info; // = cast<CTrackManiaNetworkServerInfo>(network.ServerInfo);
 
     GameInfo() {
         @app = GetTmApp();
-        @network = cast<CTrackManiaNetwork>(app.Network);
-        @server_info = cast<CTrackManiaNetworkServerInfo>(network.ServerInfo);
+    }
+
+    CTrackManiaNetwork@ GetNetwork() {
+        return cast<CTrackManiaNetwork>(app.Network);
+    }
+
+    CTrackManiaNetworkServerInfo@ GetServerInfo() {
+        return cast<CTrackManiaNetworkServerInfo>(network.ServerInfo);
     }
 
     bool IsCotd() {
+        auto network = GetNetwork();
+        auto server_info = GetServerInfo();
         return network.ClientManiaAppPlayground !is null
             && network.ClientManiaAppPlayground.Playground !is null
             && server_info.CurGameModeStr == "TM_TimeAttackDaily_Online";
@@ -399,9 +407,5 @@ class GameInfo {
         }
 #endif
         return (rm is null) ? "" : rm.IdName;
-        // if (rm is null) {
-        //     return "";
-        // }
-        // return rm.IdName;
     }
 }

--- a/src/COTDStats.as
+++ b/src/COTDStats.as
@@ -73,7 +73,12 @@ void Render() {
             windowFlags |= UI::WindowFlags::NoInputs;
         }
 
-        UI::Begin("COTD Qualifying 2", windowFlags);
+// We need a different window name to run multiple copies of the plugin (otherwise everything gets drawn in one window)
+#if DEV
+        UI::Begin("COTD Qualifying (Dev)", windowFlags);
+#else
+        UI::Begin("COTD Qualifying", windowFlags);
+#endif
 
         UI::PushStyleVar(UI::StyleVar::ItemSpacing, vec2(0, 0));
         UI::Dummy(vec2(0, 0));
@@ -361,6 +366,7 @@ class CotdApi {
 
 class GameInfo {
     CTrackMania@ app; // = GetTmApp();
+    // todo: these references might change -- refactor to getter functions or something
     CTrackManiaNetwork@ network; // = cast<CTrackManiaNetwork>(app.Network);
     CTrackManiaNetworkServerInfo@ server_info; // = cast<CTrackManiaNetworkServerInfo>(network.ServerInfo);
 

--- a/src/COTDStats.as
+++ b/src/COTDStats.as
@@ -32,7 +32,7 @@ class DivTime {
     }
 
     string TimeString() {
-        return this.style + (((this.time > 0) && (this.time != 9999999)) ? Time::Format(this.time) : "-:--.---") + "\\$z";
+        return this.style + (((this.time > 0) && (this.time <= 999999)) ? Time::Format(this.time) : "-:--.---") + "\\$z";
     }
 
     int opCmp(DivTime@ other) {
@@ -216,7 +216,7 @@ void SetDivCutoff(CotdApi@ api, DivTime@&in divObj, int cid, string mid, int div
             auto res = api.GetCutoffForDiv(cid, mid, div);
             divObj.time = (res.Length > 0) ? res[0]["time"] : 0;
         } else { // when the division isn't full
-            divObj.time = 0;
+            divObj.time = 9999999;
         }
         divObj.div = "" + div;
         divObj.hidden = false;

--- a/src/COTDStats.as
+++ b/src/COTDStats.as
@@ -99,7 +99,7 @@ void Render() {
         UI::Text(cotdName);
         UI::TableNextRow();
         UI::TableNextColumn();
-        UI::Text("Updated: " + ((Time::get_Now() - lastUpdated) / 1000.) + " s ago");
+        UI::Text("Updated: " + Text::Format("%.1f", (Time::get_Now() - lastUpdated) / 1000.) + " s ago");
         UI::TableNextRow();
         UI::TableNextColumn();
         UI::Text("\\$aaa" + totalPlayers + " players (" + Math::Ceil(totalPlayers/64.0) + " divs)\\$z");


### PR DESCRIPTION
I wanted some more divs to show in COTDStats, here's the draft implementation.

I also did a substantial refactor of API calls and "GameInfo" stuff.

If this is something you'd consider merging, I'm happy to polish things up and whatever to bring it in line with what you'd like.

Here's a low quality screenshot of both of them to give you an idea of the changes (note: there's a bug with the div6 time b/c it wasn't full)

![image](https://user-images.githubusercontent.com/1046448/167758265-a7fcb116-9536-4acd-8a29-f6dc4abebe28.png)

Additional stuff:

* I changed the API loop logic to update all divs about ~100ms after a new PB instead of the next time 15s rolls around

### todos (incomplete list)

- [ ] refactor GameInfo to not store persistent refs to some objs
- [ ] ??
